### PR TITLE
Counter-offer for alternative configuration syntax

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,34 @@
+# Deyan's proposal
+
+## Language
+
+### provides:
+  A description of the profile
+### dependencies:
+  Ordered list of profiles to be loaded in a standard DFS traversal
+### defaults:
+  Default values for options, only set if no explicit value has been set at the **end** of configuration
+  * If multiple --profiles are provided on the command-line, the defaults are set right-to-left (if needed).
+
+### requires:
+  Required options for this profile, set immediately during configuration.
+  * If multiple --profiles are provided on the command-line, the defaults are set left-to-right (potentially overwritten).
+
+**High-level goal**: Any entry appearing in "requires" and "defaults" should be exposed as a user-facing customization switch. Customization which is intended to never face users should reside in the "definitions" section, such as the phases and classes of processors.
+
+## Algorithm
+  The profile expansion happens inside the high-level option expansion pass, which processes options provided to the executable (command-line or server parameters).
+
+### Profile expansion
+  0. Initialize a CFG_OPTS options hash local to this profile
+  1. Load profile file and parse YAML definitions
+  2. DFS descent into dependencies, go to 1. for each, passing in the current CFG_OPTS
+  3. Process definitions. On collisions, merge definition hashes, overwriting key values where needed
+  4. Process "requires". On collisions, overwrite values.
+  5. Suspend processing "defaults" by pushing them on a global DEFAULTS_OPTS
+  6. Return the assembled CFG_OPTS
+  
+### High-level option expansion
+  1. Parse options, deferring to profile expansion on --profile and --format
+  2. The parsing happens left-to-right, where collisions are overwritten as appropriate
+  3. Use the assembled DEFAULT_OPTS to fill in any missing option values

--- a/bin/show.pl
+++ b/bin/show.pl
@@ -1,0 +1,74 @@
+#!/usr/bin/perl -w
+use strict;
+use warnings;
+use YAML::Tiny;
+use Data::Dumper;
+
+my @choices = grep {defined} map {/^--([\w\-]+)=([\w\-.]+)$/ && ($1,$2);} @ARGV;
+
+# Note that we are still building the full array of options that LaTeXML needs,
+#  in order to then build an options hash; as we are trying to be backwards compat.
+#  and manage e.g. --path=foo --path=bar or --pmml --nopmml --cmml
+my @options = ();
+my $defaults = {};
+my $definitions = {};
+
+# Parse options:
+while (my ($k, $v) = splice(@choices,0,2)) {
+  # Load if profile:
+  if (($k eq 'profile') || ($k eq 'format')) {
+    my $profile_spec = load_profile(name=>$v, defaults=>$defaults, definitions=>$definitions); 
+    my $cfg_opts = $profile_spec->{cfg_opts};
+    # Simply append to @options:
+    @options = (@options, %$cfg_opts); }
+  # Otherwise simple overwrite (for basic example):
+  else { push @options, ($k,$v); } }
+
+# Simple overwrite with defaults:
+@options = (%$defaults, @options);
+
+# Result:
+my @printable = ();
+while (my ($k, $v) = splice(@options,0,2)) {
+  push @printable, [$k, $v]; }
+print STDERR Dumper(\@printable);
+
+# Definitions:
+print STDERR Dumper($definitions);
+
+### ------------------------------------------
+### Profile logic:
+sub load_profile {
+  my (%options) = @_;
+  my ($name, $defaults, $cfg_opts, $definitions) = map {$options{$_}} qw(name defaults cfg_opts definitions);
+  # 0. Initialize a CFG_OPTS options hash local to this profile
+  $cfg_opts = {} unless defined $cfg_opts;
+  $definitions = {} unless defined $definitions;
+  $defaults = {} unless defined $defaults;
+  # 1. Load profile file and parse YAML definitions
+  my $yaml = YAML::Tiny->read("lib/AltConfig/$name.ltxcfg");
+  return [] unless $yaml && $yaml->[0];
+  my $cfg = $yaml->[0];
+  
+  # 2. DFS descent into dependencies, go to 1. for each, passing in the current CFG_OPTS
+  foreach my $dependency(@{($cfg->{dependencies} || [])}) {
+    load_profile(name=>$dependency, defaults=>$defaults, cfg_opts=>$cfg_opts, definitions=>$definitions); }
+
+  # 3. Process definitions. On collisions, merge definition hashes, overwriting key values where needed
+  foreach my $processor(keys %{$cfg->{definitions} || {}}) {
+    $definitions->{$processor} = {} unless defined $definitions->{$processor};
+    my $defs_processor = $definitions->{$processor};
+    foreach my $pk (keys %{$cfg->{definitions}->{$processor}}) {
+      $defs_processor->{$pk} = $cfg->{definitions}->{$processor}->{$pk}; } 
+    print STDERR " Done with processor.\n"; }
+  # 4. Process "requires". On collisions, overwrite values.
+  foreach my $key (keys %{$cfg->{requires} || {}}) {
+    $cfg_opts->{$key} = $cfg->{requires}->{$key}; }
+  
+  # 5. Suspend processing "defaults" by pushing them on a global DEFAULTS_OPTS
+  foreach my $key (keys %{$cfg->{defaults} || {}}) {
+    $defaults->{$key} = $cfg->{defaults}->{$key}; }
+  
+  # 6. Return the assembled CFG_OPTS
+  return {cfg_opts => $cfg_opts, definitions => $definitions, defaults => $defaults};
+}

--- a/bin/show.pl
+++ b/bin/show.pl
@@ -59,8 +59,7 @@ sub load_profile {
     $definitions->{$processor} = {} unless defined $definitions->{$processor};
     my $defs_processor = $definitions->{$processor};
     foreach my $pk (keys %{$cfg->{definitions}->{$processor}}) {
-      $defs_processor->{$pk} = $cfg->{definitions}->{$processor}->{$pk}; } 
-    print STDERR " Done with processor.\n"; }
+      $defs_processor->{$pk} = $cfg->{definitions}->{$processor}->{$pk}; } }
   # 4. Process "requires". On collisions, overwrite values.
   foreach my $key (keys %{$cfg->{requires} || {}}) {
     $cfg_opts->{$key} = $cfg->{requires}->{$key}; }

--- a/lib/AltConfig/LaTeXML-base.ltxcfg
+++ b/lib/AltConfig/LaTeXML-base.ltxcfg
@@ -1,0 +1,33 @@
+#  -*- mode:yaml -*-
+provides:
+  - The base configuration architecture of LaTeXML
+  - definitions of all processing "phase"s
+
+defines:
+  meta:
+    phases: 
+      - digestion
+      - split
+      - scan
+      - crossref
+      - fillin
+      - translate-graphics
+      - translate-math
+      - translate-document
+      - package-output
+
+defaults:
+  destination: STDOUT
+  basedir: .
+  log: STDERR
+  paths: 
+    - '.'
+  strict: false
+  validate: false
+  verbosity: 0
+  preload: []
+  includecomments: false
+  documentid: ""
+  preamble: ""
+  postamble: ""
+  timeout: 600

--- a/lib/AltConfig/LaTeXML-core.ltxcfg
+++ b/lib/AltConfig/LaTeXML-core.ltxcfg
@@ -1,0 +1,43 @@
+#  -*- mode:yaml -*-
+provides:
+  - The base configuration for TeX to XML processing by LaTeXML
+  - Definitions of all core processors in the "digest" phase
+
+dependencies:
+ - LaTeXML_base
+
+defines:
+  digest:
+    phase: digestion
+    class: LaTeXML::Core
+    defaults:
+      includestyles: false
+      inputencoding: ""
+  bib:
+    input-extension: bib
+    preload: BibTeX.pool.ltxml
+    after:
+      - digest
+    
+  rewrite:
+    phase: digestion
+    class: LaTeXML::Core::Rewrite
+    after:
+      - digest
+
+  mathparser:
+    phase: digestion
+    class: LaTeXML::MathParser
+    after:
+      - rewrite
+    defaults:
+      engine: Parse::RecDescent
+      grammar: MathGrammar
+
+defaults:
+  rewrite: enabled
+  mathparser: enabled
+
+requires:
+  digest: enabled
+  preload: TeX.pool.ltxml

--- a/lib/AltConfig/LaTeXML-full.ltxcfg
+++ b/lib/AltConfig/LaTeXML-full.ltxcfg
@@ -1,0 +1,16 @@
+#  -*- mode:yaml -*-
+provides:
+  - Unified core and post LaTeXML processing
+  - Default configuration for daemonized execution of LaTeXML
+dependencies:
+  - LaTeXML-core
+  - LaTeXML-post
+
+defaults:
+  # Daemon, which happens to be global:
+  whatsin: document
+  whatsout: document
+  input_limit: 1000 # 1000 documents
+  expire: 60
+  address: 127.0.0.1'
+  port: 3334

--- a/lib/AltConfig/LaTeXML-post.ltxcfg
+++ b/lib/AltConfig/LaTeXML-post.ltxcfg
@@ -1,0 +1,132 @@
+#  -*- mode:yaml -*-
+provides:
+  - The base configuration for LaTeXML post-processing
+  - definitions of all core post-processors
+dependencies:
+  - LaTeXML-base
+
+definitions:
+  split:
+    phase: split
+    class: LaTeXML::Post::Split
+    defaults:
+      splitat: ""
+      splitpath: ""
+      splitnaming: ""
+
+  scan:
+    phase: scan
+    class: LaTeXML::Post::Scan
+
+  crossref:
+    phase: crossref
+    class: LaTeXML::Post::CrossRef
+    defaults:
+      urlstyle: ""
+      navigation_toc: ""
+      numbersections: true
+
+  mathimages:
+    phase: translate-math
+    class: LaTeXML::Post::MathImages
+    defaults:
+      magnification: 1
+
+  mathsvg:
+    phase: translate-math
+    class: LaTeXML::Post::MathImages
+
+  pmml:
+    phase: translate-math
+    class: LaTeXML::Post::MathML::Presentation
+    defaults:
+      linelength: ""
+      plane1: true
+      hackplane1: false
+      unicodemap: ""
+
+  cmml:
+    phase: translate-math
+    class: LaTeXML::Post::MathML::Content
+    defaults:
+      mode: pragmatic # as opposde to strict?
+
+  om:
+    phase: translate-math
+    class: LaTeXML::Post::OpenMath
+
+  xmath:
+    phase: translate-math
+    class: LaTeXML::Post::XMath
+  
+  mathtex:
+    phase: translate-math
+    class: LaTeXML::Post::TeXMath
+
+  graphics:
+    phase: translate-graphics
+    class: LaTeXML::Post::Graphics
+    defaults:
+      maps: []
+
+  picturesvg:
+    phase: translate-graphics
+    class: LaTeXML::Post::SVG
+
+  pictureimages:
+    phase: translate-graphics
+    class: LaTeXML::Post::PictureImages
+
+  bibliography :
+    phase: fillin
+    class: LaTeXML::Post::MakeBibliograpy
+    defaults:
+      sources: []
+      split: false
+
+  index :
+    phase: fillin
+    class: LaTeXML::Post::MakeIndex
+    defaults:
+      permuted: false
+      split: false
+
+  xslt :
+    phase: translate-document
+    class: LaTeXML::Post::XSLT
+    defaults:
+      stylesheet: ""
+      timestamp: ""
+      defaultresources: true
+      css: []
+      javascript: []
+      icon: ""
+      parameters: []
+
+  manifest:
+    phase: package-output
+    class: LaTeXML::Post::Manifest
+
+  packager:
+    phase: package-output
+    class: LaTeXML::Post::Pack
+    after: 
+     - manifest
+
+  writer :
+    phase: package-output
+    class: LaTeXML::Post::Writer
+    after: 
+     - packager
+    defaults:
+      omitdoctype: false
+
+defaults:
+  dbfile: ""
+  scan: enabled
+  crossref: enabled
+  bibliography: enabled
+  index: enabled
+  graphics: enabled
+  packager: enabled
+  writer: enabled

--- a/lib/AltConfig/epub.ltxcfg
+++ b/lib/AltConfig/epub.ltxcfg
@@ -1,0 +1,17 @@
+#  -*- mode:yaml -*-
+provides:
+ - An ePub3 output format for LaTeXML
+dependencies:
+ - xhtml
+
+defines:
+  manifest:
+    class: LaTeXML::Post::Manifest::Epub
+  packager:
+    class: LaTeXML::Post::Zip
+
+requires:
+  xslt: enabled
+  manifest: enabled
+  packager: enabled
+  stylesheet: LaTeXML-epub3.xslt

--- a/lib/AltConfig/html5.ltxcfg
+++ b/lib/AltConfig/html5.ltxcfg
@@ -1,0 +1,13 @@
+#  -*- mode:yaml -*-
+provides: 
+ - A HTML5 output format configuration for LaTeXML post-processing
+dependencies:
+ - LaTeXML-post
+
+defaults:
+  pmml: enabled
+  picturesvg: enabled
+
+requires:
+  xslt: enabled
+  stylesheet: LaTeXML-html5.xsl

--- a/lib/AltConfig/xhtml.ltxcfg
+++ b/lib/AltConfig/xhtml.ltxcfg
@@ -1,0 +1,13 @@
+#  -*- mode:yaml -*-
+provides: 
+ - An XHTML output format configuration for LaTeXML
+dependencies:
+ - LaTeXML-post
+
+defaults:
+  pmml: enabled
+  picturesvg: enabled
+
+requires:
+  xslt: enabled
+  stylesheet: LaTeXML-xhtml.xsl


### PR DESCRIPTION
Example use:

```
perl bin/show.pl --format=html5 --destination=foo.html
```

Still TODO:
- Error-checking
- The distinction between global keys and processor keys is unclear, I suggest making only user-facing keys global, see DESIGN.md. However, I have not implemented that suggestion, the state is somewhat in-between.

I have come to enjoy the separation of processor definitions and user-facing options, so that we avoid having to wonder whether `--processor=enabled` overwrites the actual processor definition. It can't, as they are in separate sections.

Similarly, I would like to forbid user-facing (= command-line or request parameters) customization of technical properties of processors, it would be great if they are only accessible via the profiles mechanism.
